### PR TITLE
Fix safety check false positives when no vulnerabilities found

### DIFF
--- a/tests/security/test_security.py
+++ b/tests/security/test_security.py
@@ -101,6 +101,14 @@ class SecurityTester:
             else:
                 try:
                     vulnerabilities = json.loads(result.stdout) if result.stdout else []
+
+                    # Check if any vulnerabilities were actually found
+                    if len(vulnerabilities) == 0:
+                        logger.info(
+                            "No known security vulnerabilities found in dependencies"
+                        )
+                        return True, None
+
                     logger.warning(
                         f"Found {len(vulnerabilities)} security vulnerabilities"
                     )
@@ -114,7 +122,7 @@ class SecurityTester:
                             f"Vulnerability in {package} {version}: {vulnerability_id}"
                         )
 
-                    return False, vulnerabilities
+                    return False, {"vulnerabilities": vulnerabilities}
                 except json.JSONDecodeError:
                     logger.error("Failed to parse safety output as JSON")
                     logger.error(f"Safety stderr: {result.stderr}")
@@ -308,7 +316,7 @@ class SecurityTester:
             "safety_check": {
                 "status": "PASS" if safety_success else "FAIL",
                 "vulnerabilities_found": (
-                    len(safety_data)
+                    len(safety_data.get("vulnerabilities", []))
                     if safety_data and not safety_data.get("network_error")
                     else 0
                 ),


### PR DESCRIPTION
## Problem

The security tests were failing in CI/CD for dependabot PRs even when no actual vulnerabilities were found. The `safety` tool was returning a non-zero exit code (likely due to API changes, deprecation warnings, or other non-critical issues), but the test logic assumed any non-zero exit code meant vulnerabilities were present.

## Solution

This PR fixes two issues in `test_security.py`:

1. **Check for zero vulnerabilities**: When safety returns non-zero exit code, now checks if the parsed JSON contains 0 vulnerabilities and returns `True` (pass) instead of automatically failing
2. **Fix type signature**: Wrapped vulnerabilities list in a dict structure to match the expected return type `Tuple[bool, Optional[Dict]]`

## Changes

- Added check at line 107-109: If `len(vulnerabilities) == 0`, return success
- Changed line 123: Return `{"vulnerabilities": vulnerabilities}` instead of raw list
- Updated line 312: Access vulnerabilities via `safety_data.get("vulnerabilities", [])`

## Testing

- ✅ Local tests pass: `python tests/run_tests.py --security`
- ✅ Security summary shows correct status
- ✅ Type errors resolved

This should resolve the CI/CD failures on all recent dependabot pull requests.